### PR TITLE
Add support for new BigQuery types and aliases

### DIFF
--- a/mo_sql_parsing/types.py
+++ b/mo_sql_parsing/types.py
@@ -47,12 +47,15 @@ BOOL = Group(keyword("bool")("op")) / to_json_call
 BOOLEAN = Group(keyword("boolean")("op")) / to_json_call
 DOUBLE = Group(keyword("double")("op") + Optional(flag("unsigned"))) / to_json_call
 FLOAT64 = Group(keyword("float64")("op")) / to_json_call
+BIGNUMERIC = Group(keyword("bignumeric")("op")) / to_json_call
+BIGDECIMAL = Group(keyword("bigdecimal")("op")) / to_json_call
 FLOAT = Group(keyword("float")("op") + Optional(flag("unsigned"))) / to_json_call
 GEOMETRY = Group(keyword("geometry")("op")) / to_json_call
 INTEGER = Group(keyword("integer")("op") + Optional(flag("unsigned"))) / to_json_call
 INT = (keyword("int")("op") + _size + Optional(flag("unsigned"))) / to_json_call
 INT32 = Group(keyword("int32")("op")) / to_json_call
 INT64 = Group(keyword("int64")("op")) / to_json_call
+BYTEINT = Group(keyword("byteint")("op")) / to_json_call
 REAL = Group(keyword("real")("op") + Optional(flag("unsigned"))) / to_json_call
 TEXT = Group(keyword("text")("op")) / to_json_call
 SMALLINT = Group(keyword("smallint")("op") + Optional(flag("unsigned"))) / to_json_call
@@ -120,6 +123,8 @@ simple_types << MatchFirst([
     DOUBLE_PRECISION,
     DOUBLE,
     FLOAT64,
+    BIGNUMERIC,
+    BIGDECIMAL,
     FLOAT,
     GEOMETRY,
     MAP_TYPE,
@@ -127,6 +132,7 @@ simple_types << MatchFirst([
     INT,
     INT32,
     INT64,
+    BYTEINT,
     JSON,
     NCHAR,
     NUMBER,

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -392,6 +392,60 @@ class TestBigQuery(TestCase):
         result = parse(sql)
         expected = {"from": "a.b.c", "select": "*"}
         self.assertEqual(result, expected)
+    
+    def testV(self):
+        sql = """SELECT * FROM `a.b.c` a1
+                JOIN `a.b.d` t2
+                    ON cast(a1.field AS BIGDECIMAL) = cast(a2.field AS BIGNUMERIC)"""
+        result = parse(sql)
+        expected = {
+            'select': '*',
+            'from': [
+                {'value': 'a..b..c', 'name': 'a1'},
+                {
+                    'join': {'value': 'a..b..d', 'name': 't2'},
+                    'on': {
+                        'eq': [{
+                            'cast': ['a1.field', {
+                                'bigdecimal': {}
+                            }]
+                        }, {
+                            'cast': ['a2.field', {
+                                'bignumeric': {}
+                            }]
+                        }]
+                    }
+                }
+            ]
+        }
+        self.assertEqual(result, expected)
+    
+    def testW(self):
+        sql = """SELECT * FROM `a.b.c` a1
+                JOIN `a.b.d` t2
+                    ON cast(a1.field AS INT64) = cast(a2.field AS BYTEINT)"""
+        result = parse(sql)
+        expected = {
+            'select': '*',
+            'from': [
+                {'value': 'a..b..c', 'name': 'a1'},
+                {
+                'join': {'value': 'a..b..d', 'name': 't2'},
+                'on': {
+                    'eq': [{
+                        'cast': ['a1.field', {
+                            'int64': {}
+                        }]
+                    }, {
+                        'cast': ['a2.field', {
+                            'byteint': {}
+                        }]
+                    }]
+                }
+                }
+            ]
+        }
+        self.assertEqual(result, expected)
 
 
 class TestBigQuery2(FuzzyTestCase):

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -395,7 +395,7 @@ class TestBigQuery(TestCase):
     
     def testV(self):
         sql = """SELECT * FROM `a.b.c` a1
-                JOIN `a.b.d` t2
+                JOIN `a.b.d` a2
                     ON cast(a1.field AS BIGDECIMAL) = cast(a2.field AS BIGNUMERIC)"""
         result = parse(sql)
         expected = {
@@ -403,7 +403,7 @@ class TestBigQuery(TestCase):
             'from': [
                 {'value': 'a..b..c', 'name': 'a1'},
                 {
-                    'join': {'value': 'a..b..d', 'name': 't2'},
+                    'join': {'value': 'a..b..d', 'name': 'a2'},
                     'on': {
                         'eq': [{
                             'cast': ['a1.field', {
@@ -422,7 +422,7 @@ class TestBigQuery(TestCase):
     
     def testW(self):
         sql = """SELECT * FROM `a.b.c` a1
-                JOIN `a.b.d` t2
+                JOIN `a.b.d` a2
                     ON cast(a1.field AS INT64) = cast(a2.field AS BYTEINT)"""
         result = parse(sql)
         expected = {
@@ -430,7 +430,7 @@ class TestBigQuery(TestCase):
             'from': [
                 {'value': 'a..b..c', 'name': 'a1'},
                 {
-                'join': {'value': 'a..b..d', 'name': 't2'},
+                'join': {'value': 'a..b..d', 'name': 'a2'},
                 'on': {
                     'eq': [{
                         'cast': ['a1.field', {


### PR DESCRIPTION
@klahnakoski, thank you very much for maintaining this project, it helped me immensely!

BigQuery have a unique set of fields types that include a few aliases that are not currently supported in **mo-sql-parsing**. This makes the lib to raise an exception when parsing queries that contained any of those fields.

This pull request introduces all the types and aliases that I could find that were not already in the lib. You can check all the field types and aliases in the [BigQuery documentation](https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#bytes_type).