### PR TITLE
Fix for subquery as parameter in function

### DIFF
--- a/mo_sql_parsing/formatting.py
+++ b/mo_sql_parsing/formatting.py
@@ -310,7 +310,10 @@ class Formatter:
         if isinstance(value, dict) and len(value) == 0:
             return key.upper() + "()"  # NOT SURE IF AN EMPTY dict SHOULD BE DELT WITH HERE, OR IN self.format()
         else:
-            params = ", ".join(self.dispatch(p) for p in listwrap(value))
+            params = ", ".join(
+                self.dispatch(p) if "select" not in p else f"({self.dispatch(p)})"
+                for p in listwrap(value)
+            )
             return f"{key.upper()}({params})"
 
     def _binary_not(self, value, prec):

--- a/mo_sql_parsing/formatting.py
+++ b/mo_sql_parsing/formatting.py
@@ -311,7 +311,7 @@ class Formatter:
             return key.upper() + "()"  # NOT SURE IF AN EMPTY dict SHOULD BE DELT WITH HERE, OR IN self.format()
         else:
             params = ", ".join(
-                self.dispatch(p) if "select" not in p else f"({self.dispatch(p)})"
+                f"({self.dispatch(p)})" if isinstance(p, dict) and"select" in p else self.dispatch(p)
                 for p in listwrap(value)
             )
             return f"{key.upper()}({params})"

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -745,3 +745,9 @@ class TestSimple(TestCase):
         result = parse(sql)
         formatted = format(parse(sql))
         self.assertEqual(formatted, sql)
+
+    def test_subquery_as_param_format_back(self):
+        sql = """SELECT DATEDIFF(mm, dwperiod, (SELECT MAX(dwperiod) FROM bdv.S_SKADA_C)) AS A FROM be"""
+        result = parse(sql)
+        formatted = format(parse(sql))
+        self.assertEqual(formatted, sql)


### PR DESCRIPTION
Hello Kyle, 

This PR will fix the issue with parser, where brackets was removed from subqueries, that are used in functions. Similar issue: https://github.com/klahnakoski/mo-sql-parsing/issues/87