### PR TITLE
Add support for NOT REGEXP operator in queries

### DIFF
--- a/mo_sql_parsing/formatting.py
+++ b/mo_sql_parsing/formatting.py
@@ -315,6 +315,9 @@ class Formatter:
     def _regexp(self, value, prec):
         return f"{self.dispatch(value[0])} REGEXP {self.dispatch(value[1])}"
 
+    def _not_regexp(self, value, prec):
+        return f"{self.dispatch(value[0])} NOT REGEXP {self.dispatch(value[1])}"
+
     def _binary_not(self, value, prec):
         return "~{0}".format(self.dispatch(value))
 

--- a/mo_sql_parsing/keywords.py
+++ b/mo_sql_parsing/keywords.py
@@ -166,6 +166,7 @@ NOT_ILIKE = Group(NOT + ILIKE).set_parser_name("not_ilike")
 NOT_LIKE = Group(NOT + LIKE).set_parser_name("not_like")
 NOT_RLIKE = Group(NOT + RLIKE).set_parser_name("not_rlike")
 NOT_IN = Group(NOT + IN).set_parser_name("nin")
+NOT_REGEXP = Group(NOT + REGEXP).set_parser_name("not_regexp")
 IS_NOT = Group(IS + NOT).set_parser_name("is_not")
 
 _SIMILAR = keyword("similar")
@@ -289,6 +290,7 @@ precedence = {
     "gt": 6,
     "eq": 7,
     "rgx": 7,
+    "not_rgx": 7,
     "neq": 7,
     "missing": 7,
     "exists": 7,
@@ -356,6 +358,7 @@ KNOWN_OPS = [
     OR,
     LAMBDA,
     REGEXP,
+    NOT_REGEXP,
 ]
 
 times = ["now", "today", "tomorrow", "eod"]

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -765,9 +765,14 @@ class TestSimple(TestCase):
         result = format(parse(sql))
         self.assertEqual(result, expected)
 
-
     def test_regexp_formated(self):
         sql = """SELECT * FROM dbo.table WHERE col REGEXP '[^0-9A-Za-z]'"""
         expected = """SELECT * FROM dbo.table WHERE col REGEXP '[^0-9A-Za-z]'"""
+        result = format(parse(sql))
+        self.assertEqual(result, expected)
+
+    def test_not_regexp_formated(self):
+        sql = """SELECT * FROM dbo.table WHERE col NOT REGEXP '[^0-9A-Za-z]'"""
+        expected = """SELECT * FROM dbo.table WHERE col NOT REGEXP '[^0-9A-Za-z]'"""
         result = format(parse(sql))
         self.assertEqual(result, expected)

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -363,8 +363,14 @@ class TestMySql(TestCase):
         }}
         self.assertEqual(result, expected)
 
-    def test_issue_185_index_length(self):
+    def test_regexp(self):
         sql = """SELECT * FROM dbo.table where col  REGEXP '[^0-9A-Za-z]'"""
         result = parse(sql)
         expected = {'select': '*', 'from': 'dbo.table', 'where': {'regexp': ['col', {'literal': '[^0-9A-Za-z]'}]}}
+        self.assertEqual(result, expected)
+
+    def test_not_regexp(self):
+        sql = """SELECT * FROM dbo.table where col NOT REGEXP '[^0-9A-Za-z]'"""
+        result = parse(sql)
+        expected = {'select': '*', 'from': 'dbo.table', 'where': {'not_regexp': ['col', {'literal': '[^0-9A-Za-z]'}]}}
         self.assertEqual(result, expected)


### PR DESCRIPTION
Hello Kyle!

#190 there was a missed inclusion of support for the "NOT REGEXP" operator in the modifications. This PR has been updated to include this operator's support. Additionally, I've add test cases and resolved an issue where a duplicate test case name existed.




.