### PR TITLE
Fixed primary key using btree

### DIFF
--- a/mo_sql_parsing/sql_parser.py
+++ b/mo_sql_parsing/sql_parser.py
@@ -571,7 +571,7 @@ def parser(literal_string, simple_ident, sqlserver=False):
         index_options = ZeroOrMore(identifier / (lambda t: {t[0]: True}))
 
         table_constraint_definition = Optional(CONSTRAINT + identifier("name")) + (
-            assign("primary key", index_type + index_column_names + index_options)
+            assign("primary key", index_type + index_column_names + index_type + index_options)
             | (
                 Optional(flag("unique"))
                 + Optional(INDEX | KEY)

--- a/tests/test_mysql.py
+++ b/tests/test_mysql.py
@@ -296,6 +296,26 @@ class TestMySql(TestCase):
         }}
         self.assertEqual(result, expected)
 
+    def test_using_btree_in_primary_key_1(self):
+        sql = """create table tt (n varchar(10), nn varchar(6), primary key (`nn`) using btree );"""
+        result = parse(sql)
+        expected = {"create table": {
+            "columns": [{"name": "n", "type": {"varchar": 10}}, {"name": "nn", "type": {"varchar": 6}}],
+            "constraint": {"primary_key": {"columns": "nn", "using": "btree"}},
+            "name": "tt",
+        }}
+        self.assertEqual(result, expected)
+
+    def test_using_btree_in_primary_key_2(self):
+        sql = """create table tt (n varchar(10), nn varchar(6), primary key using btree (`nn`) );"""
+        result = parse(sql)
+        expected = {"create table": {
+            "columns": [{"name": "n", "type": {"varchar": 10}}, {"name": "nn", "type": {"varchar": 6}}],
+            "constraint": {"primary_key": {"columns": "nn", "using": "btree"}},
+            "name": "tt",
+        }}
+        self.assertEqual(result, expected)
+
     def test_issue_186_limit(self):
         sql = """SELECT * from t1 limit 1,10"""
         result = parse(sql)


### PR DESCRIPTION
add support for syntax like:

```create table tt (n varchar(10), nn varchar(6), primary key (`nn`) using btree )```

and add some tests.