### PR TITLE
Add support for other sintax of time-travel on BigQuery 

### DIFF
--- a/mo_sql_parsing/sql_parser.py
+++ b/mo_sql_parsing/sql_parser.py
@@ -479,6 +479,7 @@ def parser(literal_string, simple_ident, sqlserver=False):
                 Optional(WITH + OFFSET + Optional(AS) + ident("with_offset")),
                 Optional(tablesample),
                 Optional(assign("for system_time as of", expression)),
+                Optional(assign("for system time as of", expression)),
                 alias,
             ])
         ) / to_table

--- a/tests/test_bigquery.py
+++ b/tests/test_bigquery.py
@@ -1538,3 +1538,19 @@ class TestBigQuery(TestCase):
             "select": "*",
         }
         self.assertEqual(result, expected)
+
+    def test_issue_210(self):
+        # https://cloud.google.com/bigquery/docs/access-historical-data#query_data_at_a_point_in_time
+        sql = """SELECT *
+        FROM `mydataset.mytable`
+          FOR SYSTEM TIME AS OF TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL 1 HOUR);
+        """
+        result = parse(sql)
+        expected = {
+            "from": {
+                "for_system_time_as_of": {"timestamp_sub": [{"current_timestamp": {}}, {"interval": [1, "hour"]}]},
+                "value": "mydataset..mytable",
+            },
+            "select": "*",
+        }
+        self.assertEqual(result, expected)


### PR DESCRIPTION
Fix https://github.com/klahnakoski/mo-sql-parsing/issues/210.
The time-travel function on BigQuery is also supported by the syntax `FOR SYSTEM TIME AS OF,` so this PR adds this support. Considering this project's guidelines, I don't know if this is the best way, but I'm open to learning a better way and changing it if necessary. 