### PR TITLE
Parser was removing single quotes around INTERVAL value which are required on PostgreSQL

### DIFF
--- a/mo_sql_parsing/formatting.py
+++ b/mo_sql_parsing/formatting.py
@@ -423,7 +423,7 @@ class Formatter:
     def _interval(self, json, prec):
         amount = self.dispatch(json[0], precedence["and"])
         type = self.dispatch(json[1], precedence["and"])
-        return f"INTERVAL {amount} {type.upper()}"
+        return f"INTERVAL '{amount}' {type.upper()}"
 
     def _literal(self, json, prec=0):
         if isinstance(json, list):

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -558,7 +558,7 @@ class TestSimple(TestCase):
 
     def test_issue_51_interval(self):
         result = format(parse("select now() + interval 2 week"))
-        expected = "SELECT NOW() + INTERVAL 2 WEEK"
+        expected = "SELECT NOW() + INTERVAL '2' WEEK"
         self.assertEqual(result, expected)
 
     def test_issue_65_parenthesis(self):


### PR DESCRIPTION
# Description
Had to modify the formatter to add single quotes around an interval value. Example:
Before modification: INTERVAL 1 MONTH > Fails to execute on PostgreSQL
After modification; INTERVAL '1' MONTH

# Tests
Didn't had to write a new one, simply updated the test case related to Intervals. All others test are passing.

# Remark
I am not sure/able to test for other DBs like mysql or BigQuery.

