### PR TITLE
add support for nliteral + tests

### DIFF
--- a/mo_sql_parsing/__init__.py
+++ b/mo_sql_parsing/__init__.py
@@ -14,7 +14,7 @@ from threading import Lock
 from mo_parsing import debug
 
 from mo_sql_parsing.sql_parser import scrub
-from mo_sql_parsing.utils import ansi_string, simple_op, normal_op
+from mo_sql_parsing.utils import ansi_string, simple_op, normal_op, n_string
 
 parse_locker = Lock()  # ENSURE ONLY ONE PARSING AT A TIME
 common_parser = None

--- a/mo_sql_parsing/formatting.py
+++ b/mo_sql_parsing/formatting.py
@@ -440,6 +440,16 @@ class Formatter:
         else:
             return str(json)
 
+    def _nliteral(self, json, prec=0):
+        if isinstance(json, list):
+            body = ", ".join(self._nliteral(v, precedence["nliteral"]) for v in json)
+            return f"({body})"
+        elif isinstance(json, string_types):
+            body = json.replace("'", "''")
+            return f"N'{body}'"
+        else:
+            return str(json)
+
     def _get(self, json, prec):
         v, i = json
         v_sql = self.dispatch(v, prec=precedence["literal"])

--- a/mo_sql_parsing/keywords.py
+++ b/mo_sql_parsing/keywords.py
@@ -276,6 +276,7 @@ join_keywords = {
 precedence = {
     # https://www.sqlite.org/lang_expr.html
     "literal": -1,
+    "nliteral": -1,
     "get": 0,
     "interval": 0,
     "cast": 0,

--- a/mo_sql_parsing/sql_parser.py
+++ b/mo_sql_parsing/sql_parser.py
@@ -31,7 +31,7 @@ def mysql_parser():
 
 def sqlserver_parser():
     atomic_ident = ansi_ident | mysql_backtick_ident | sqlserver_ident | simple_ident
-    return parser(regex_string | ansi_string, atomic_ident, sqlserver=True)
+    return parser(regex_string | ansi_string | n_string, atomic_ident, sqlserver=True)
 
 
 def parser(literal_string, simple_ident, sqlserver=False):

--- a/mo_sql_parsing/utils.py
+++ b/mo_sql_parsing/utils.py
@@ -727,6 +727,12 @@ def to_table(tokens):
     return [output["value"]]
 
 
+def single_nliteral(tokens):
+    val = tokens[0]
+    val = '"""' + val[2:-1].replace("''", "\\'").replace('"', '\\"') + '"""'
+    return {"nliteral": ast.literal_eval(val)}
+
+
 def single_literal(tokens):
     val = tokens[0]
     val = '"""' + val[1:-1].replace("''", "\\'").replace('"', '\\"') + '"""'
@@ -808,6 +814,7 @@ hex_num = Regex(r"0x[0-9a-fA-F]+").set_parser_name("hex") / (lambda t: {"hex": t
 
 # STRINGS
 ansi_string = Regex(r"\'(\'\'|[^'])*\'") / single_literal
+n_string = Regex(r"[nN]?\'(\'\'|[^'])*\'") / single_nliteral
 regex_string = (Regex(r'r\"(\\\"|[^"])*\"') | Regex(r"r\'(\\\'|[^'])*\'")) / literal_regex
 mysql_doublequote_string = Regex(r'\"(\"\"|[^"])*\"') / double_literal
 

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -10,7 +10,7 @@
 
 from unittest import TestCase
 
-from mo_sql_parsing import format, parse
+from mo_sql_parsing import format, parse, parse_sqlserver
 
 
 class TestSimple(TestCase):
@@ -813,3 +813,9 @@ class TestSimple(TestCase):
         expected = "SELECT group_concat(u.co_id ORDER BY u.created DESC SEPARATOR ',')"
         result = format(parse(sql))
         self.assertEqual(result, expected)
+
+
+    def test_nliteral_format(self):
+        sql = "SELECT * FROM dbo.table WHERE a = N'Something'"
+        result = format(parse_sqlserver(sql))
+        self.assertEqual(result, sql)

--- a/tests/test_sql_server.py
+++ b/tests/test_sql_server.py
@@ -260,3 +260,9 @@ class TestSqlServer(TestCase):
         result = parse(sql)
         expected = {"from": "A", "orderby": {"value": "relevance"}, "select": {"value": "Column"}, "top": 10}
         self.assertEqual(result, expected)
+
+    def test_nliteral_parse(self):
+            sql = """SELECT * FROM dbo.table WHERE a = N'Something'"""
+            result = parse(sql)
+            expected = {'select': '*', 'from': 'dbo.table', 'where': {'eq': ['a', {'nliteral': 'Something'}]}}
+            self.assertEqual(result, expected)


### PR DESCRIPTION
Hello,
Found an issue with N prefix. I'm unable to parse query ```Select * from dbo.table where a = N'Something' ``` https://learn.microsoft.com/en-us/sql/t-sql/data-types/constants-transact-sql?view=sql-server-ver16#unicode-strings

This PR will add support for it 